### PR TITLE
feat: check CI env var for silent spinner mode

### DIFF
--- a/cli/lib/progress.ts
+++ b/cli/lib/progress.ts
@@ -20,8 +20,8 @@ export interface SpinnerLike {
 }
 
 export function createSpinner(text: string): SpinnerLike {
-	// when no tty is attached or WISPCTL_NO_PROGRESS is set, return a silent spinner
-	if (!process.stdout.isTTY || process.env.WISPCTL_NO_PROGRESS === '1') {
+	// when no tty is attached, or a headless env var is set, return a silent spinner
+	if (!process.stdout.isTTY || process.env.WISPCTL_NO_PROGRESS === '1' || process.env.CI === 'true') {
 		let currentText = text
 		return {
 			get text() {


### PR DESCRIPTION
extends the existing silent spinner fallback in `progress.ts` to also check `process.env.CI === "true"`. this way CI runners and agent harnesses (like the niri one) automatically get clean log output without spinner artifacts.

related: the new `--quiet` flag and `WISPCTL_NO_PROGRESS` env var already exist, this just makes the detection more automatic for CI environments.