### PR TITLE
Prevent disk path traversal in on-demand cache and disk storage tier

### DIFF
--- a/apps/hosting-service/src/lib/on-demand-cache.ts
+++ b/apps/hosting-service/src/lib/on-demand-cache.ts
@@ -140,6 +140,9 @@ async function doFetchAndCache(did: string, rkey: string): Promise<boolean> {
 		// Expand subfs nodes
 		const expandedRoot = await expandSubfsNodes(record.root, pdsEndpoint)
 
+		// Validate untrusted manifest paths before collecting file names for storage keys.
+		validateEntryNames(expandedRoot.entries)
+
 		// Validate limits
 		const fileCount = countFilesInDirectory(expandedRoot)
 		if (fileCount > MAX_FILE_COUNT) {
@@ -203,6 +206,32 @@ async function doFetchAndCache(did: string, rkey: string): Promise<boolean> {
 	} finally {
 		await releaseLock(lockKey)
 	}
+}
+
+function validateEntryNames(entries: Entry[], pathPrefix: string = ''): void {
+	for (const entry of entries) {
+		if (!isSafeEntryName(entry.name)) {
+			const entryPath = pathPrefix ? `${pathPrefix}/${entry.name}` : entry.name
+			throw new Error(`Unsafe filesystem entry name: ${entryPath}`)
+		}
+
+		const node = entry.node
+		if ('type' in node && node.type === 'directory' && 'entries' in node) {
+			const currentPath = pathPrefix ? `${pathPrefix}/${entry.name}` : entry.name
+			validateEntryNames(node.entries, currentPath)
+		}
+	}
+}
+
+function isSafeEntryName(name: string): boolean {
+	return (
+		name !== '' &&
+		name !== '.' &&
+		name !== '..' &&
+		!name.includes('/') &&
+		!name.includes('\\') &&
+		!name.includes('\0')
+	)
 }
 
 function calculateTotalBlobSize(directory: Directory): number {

--- a/packages/@wispplace/tiered-storage/src/tiers/DiskStorageTier.ts
+++ b/packages/@wispplace/tiered-storage/src/tiers/DiskStorageTier.ts
@@ -1,6 +1,6 @@
 import { createReadStream, createWriteStream, existsSync } from 'node:fs'
 import { mkdir, readdir, readFile, rename, rm, stat, unlink, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, join, relative, resolve, sep } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import type { StorageMetadata, StorageTier, TierGetResult, TierStats, TierStreamResult } from '../types/index.js'
 import { encodeKey } from '../utils/path-encoding.js'
@@ -618,7 +618,15 @@ export class DiskStorageTier implements StorageTier {
 	 */
 	private getFilePath(key: string): string {
 		const encoded = encodeKey(key, this.encodeColons)
-		return join(this.config.directory, encoded)
+		const baseDir = resolve(this.config.directory)
+		const filePath = resolve(baseDir, encoded)
+		const relativePath = relative(baseDir, filePath)
+
+		if (relativePath === '' || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+			throw new Error(`Storage key resolves outside configured directory: ${key}`)
+		}
+
+		return filePath
 	}
 
 	/**

--- a/packages/@wispplace/tiered-storage/test/DiskStorageTier.test.ts
+++ b/packages/@wispplace/tiered-storage/test/DiskStorageTier.test.ts
@@ -5,14 +5,17 @@ import { join } from 'node:path'
 import { DiskStorageTier } from '../src/tiers/DiskStorageTier.js'
 
 const testDir = './test-disk-cache'
+const traversalTarget = './outside-disk-storage-tier-test.txt'
 
 describe('DiskStorageTier - Recursive Directory Support', () => {
 	beforeEach(async () => {
 		await rm(testDir, { recursive: true, force: true })
+		await rm(traversalTarget, { force: true })
 	})
 
 	afterAll(async () => {
 		await rm(testDir, { recursive: true, force: true })
+		await rm(traversalTarget, { force: true })
 	})
 
 	describe('Nested Directory Creation', () => {
@@ -61,6 +64,25 @@ describe('DiskStorageTier - Recursive Directory Support', () => {
 			expect(await tier.exists('site:a/images/logo.png')).toBe(true)
 			expect(await tier.exists('site:a/css/style.css')).toBe(true)
 			expect(await tier.exists('site:b/index.html')).toBe(true)
+		})
+	})
+
+	describe('Path containment', () => {
+		test('should reject keys that resolve outside the configured directory', async () => {
+			const tier = new DiskStorageTier({ directory: testDir })
+			const data = new TextEncoder().encode('evil')
+			const metadata = {
+				key: 'did:plc:attacker/site/../../../outside-disk-storage-tier-test.txt',
+				size: data.byteLength,
+				createdAt: new Date(),
+				lastAccessed: new Date(),
+				accessCount: 0,
+				compressed: false,
+				checksum: 'evil',
+			}
+
+			await expect(tier.set(metadata.key, data, metadata)).rejects.toThrow(/outside configured directory/)
+			expect(existsSync(traversalTarget)).toBe(false)
 		})
 	})
 


### PR DESCRIPTION
### Motivation
- The on-demand caching flow used untrusted Wisp filesystem manifest entry names to build storage keys, allowing `../`, `/`, null bytes, and similar payloads to escape the configured cache directory and cause arbitrary filesystem writes.
- The disk storage tier encoded keys but preserved path separators and dot segments, so `path.join(cacheDir, encodedKey)` could resolve outside the cache directory.

### Description
- Validate manifest entry names before any file/key collection by adding `validateEntryNames()` and `isSafeEntryName()` to `apps/hosting-service/src/lib/on-demand-cache.ts`, rejecting empty names, `.`/`..`, forward/back slashes, and null bytes.
- Add a containment check in `packages/@wispplace/tiered-storage/src/tiers/DiskStorageTier.ts#getFilePath` that resolves the encoded key against the configured directory and throws if the resolved path escapes the directory.
- Add a regression test `packages/@wispplace/tiered-storage/test/DiskStorageTier.test.ts` that verifies traversal-style keys (e.g. `did:plc:attacker/site/../../../outside-disk-storage-tier-test.txt`) are rejected and do not create files outside the cache directory.

### Testing
- Ran `bun test packages/@wispplace/tiered-storage/test/DiskStorageTier.test.ts` and the tiered-storage tests passed (all tests in that file succeeded).
- Ran `bun test apps/hosting-service/src/lib/file-serving.integration.test.ts packages/@wispplace/tiered-storage/test/DiskStorageTier.test.ts` which could not complete due to a missing test dependency (`@opentelemetry/api`) in the environment; the tiered-storage tests still passed in that run.
- `git diff --check` produced no whitespace or diff errors.
- Static checks (`bun run check` / `bun run lint`) could not be completed in this environment because `tsc` and `biome` binaries were not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33844f5404832fb4d0c302e9e741c7)