### PR TITLE
Validate resolver-provided DIDs against DID document before PDS discovery

### DIFF
--- a/packages/@wispplace/atproto-utils/src/identity.ts
+++ b/packages/@wispplace/atproto-utils/src/identity.ts
@@ -22,6 +22,15 @@ interface DidDocument {
 	alsoKnownAs?: string[]
 }
 
+function normalizeHandle(handle: string): string {
+	return handle.trim().toLowerCase()
+}
+
+function didDocumentIncludesHandle(doc: DidDocument, handle: string): boolean {
+	const expectedAlsoKnownAs = `at://${normalizeHandle(handle)}`
+	return (doc.alsoKnownAs || []).some((aka) => aka.toLowerCase() === expectedAlsoKnownAs)
+}
+
 /**
  * Convert a did:web to an HTTPS URL for fetching the DID document
  */
@@ -64,6 +73,12 @@ export async function resolveDid(identifier: string): Promise<string | null> {
 		}
 
 		const data = (await response.json()) as { did: string }
+		const doc = await getDidDocument(data.did)
+		if (!doc || !didDocumentIncludesHandle(doc, identifier)) {
+			console.error('Resolved DID does not match handle', identifier, data.did)
+			return null
+		}
+
 		return data.did
 	} catch (err) {
 		console.error('Failed to resolve identifier', identifier, err)


### PR DESCRIPTION
### Motivation
- Prevent a malicious or compromised handle resolver from returning an attacker-controlled DID whose DID document points at an attacker-controlled PDS and thereby capturing app-password credentials. 
- Bind resolver responses to the originally requested handle by verifying the resolved DID document advertises the expected `at://` handle.

### Description
- Add `normalizeHandle()` and `didDocumentIncludesHandle()` helpers to canonicalize handles and check whether a DID document's `alsoKnownAs` contains the expected `at://<handle>` entry. 
- Update `resolveDid()` to fetch the resolved DID's DID document via `getDidDocument()` and return `null` (with an error log) if the DID document does not include the requested handle. 
- Preserve existing behavior for identifiers that already start with `did:` so DIDs are still returned unchanged.

### Testing
- Ran `git diff --check`, which reported no whitespace or patch-format issues and completed successfully. 
- Ran `bun run check` (invokes `bun tsc --noEmit`) which failed because the environment lacks a `tsc` script or installed dependencies. 
- Ran `bun install`, which failed due to npm registry `403` responses in this environment, preventing full typecheck or runtime tests from executing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a336a273890832f8cb1b930ed0b38c2)