### PR TITLE
Fix unauthenticated HTML prewarm scan amplification

### DIFF
--- a/apps/hosting-service/src/lib/file-serving.ts
+++ b/apps/hosting-service/src/lib/file-serving.ts
@@ -414,9 +414,14 @@ export async function serveFromCache(
 			: new Response('Site is updating', { status: 503, headers: { 'Cache-Control': 'no-store', 'Retry-After': '5' } })
 	}
 
-	triggerSiteHtmlHotCacheWarmup(did, rkey)
-
 	const trace = createTrace()
+
+	// Only prewarm sites that are known to exist. Public routes can otherwise
+	// choose arbitrary site keys and force expensive storage-wide list operations.
+	const siteFileCids = await getExpectedFileCidsForSite(did, rkey, trace)
+	if (siteFileCids !== null) {
+		triggerSiteHtmlHotCacheWarmup(did, rkey)
+	}
 
 	// Load settings for this site
 	const settings = await span(trace, 'db:settings', () => getCachedSettings(did, rkey))
@@ -723,9 +728,14 @@ export async function serveFromCacheWithRewrite(
 			: new Response('Site is updating', { status: 503, headers: { 'Cache-Control': 'no-store', 'Retry-After': '5' } })
 	}
 
-	triggerSiteHtmlHotCacheWarmup(did, rkey)
-
 	const trace = createTrace()
+
+	// Only prewarm sites that are known to exist. Public routes can otherwise
+	// choose arbitrary site keys and force expensive storage-wide list operations.
+	const siteFileCids = await getExpectedFileCidsForSite(did, rkey, trace)
+	if (siteFileCids !== null) {
+		triggerSiteHtmlHotCacheWarmup(did, rkey)
+	}
 
 	// Load settings for this site
 	const settings = await span(trace, 'db:settings', () => getCachedSettings(did, rkey))

--- a/apps/hosting-service/src/lib/html-prewarm.test.ts
+++ b/apps/hosting-service/src/lib/html-prewarm.test.ts
@@ -83,7 +83,7 @@ describe('HTML prewarm', () => {
 		expect(promotedKeys).toHaveLength(2)
 	})
 
-	test('site with no cached keys is not permanently marked warm', async () => {
+	test('site with no cached keys is marked warm after a successful empty scan', async () => {
 		triggerSiteHtmlHotCacheWarmup(DID, RKEY)
 		await waitForSiteHtmlHotCacheWarmupForTests(DID, RKEY)
 		expect(promotedKeys).toHaveLength(0)
@@ -92,6 +92,6 @@ describe('HTML prewarm', () => {
 
 		triggerSiteHtmlHotCacheWarmup(DID, RKEY)
 		await waitForSiteHtmlHotCacheWarmupForTests(DID, RKEY)
-		expect(promotedKeys).toHaveLength(1)
+		expect(promotedKeys).toHaveLength(0)
 	})
 })

--- a/apps/hosting-service/src/lib/html-prewarm.ts
+++ b/apps/hosting-service/src/lib/html-prewarm.ts
@@ -54,10 +54,9 @@ export function triggerSiteHtmlHotCacheWarmup(did: string, rkey: string): void {
 				const latestGeneration = prewarmGeneration.get(siteKey) ?? 0
 				if (latestGeneration !== generation) return
 
-				// When the site doesn't exist yet, avoid permanently marking it as warmed.
-				if (scannedKeys > 0) {
-					warmedSites.add(siteKey)
-				}
+				// Remember successful scans even when there are no matching keys so repeated
+				// requests for the same missing/empty prefix cannot force repeated storage scans.
+				warmedSites.add(siteKey)
 
 				logger.debug(`HTML prewarm finished for ${did}/${rkey}`, {
 					scannedKeys,


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated requests to the public `sites.*` route from triggering expensive storage-wide listings and HTML promotion that can be abused for DoS/cost amplification. 
- Ensure the prewarm machinery dedupes repeated empty/missing-site warmups so attackers cannot re-run full cache scans by varying DID/rkey.

### Description
- Gate prewarm calls in `serveFromCache` and `serveFromCacheWithRewrite` so `triggerSiteHtmlHotCacheWarmup(did, rkey)` is only invoked when the site is known to exist via `getExpectedFileCidsForSite(did, rkey, trace)` (file: `apps/hosting-service/src/lib/file-serving.ts`).
- Change prewarm bookkeeping to mark a site as warmed after any successful scan (including zero-key scans) so repeated requests for the same missing/empty prefix do not re-run storage listings (file: `apps/hosting-service/src/lib/html-prewarm.ts`).
- Update unit test expectations to reflect the new dedupe behavior for empty scans and keep reset behavior intact (file: `apps/hosting-service/src/lib/html-prewarm.test.ts`).

### Testing
- Ran `git diff --check` which reported no problems after the changes (success).
- Attempted `bun test apps/hosting-service/src/lib/html-prewarm.test.ts` but it failed to run in this environment due to missing dependency `@opentelemetry/api` and `bun install` being blocked by registry `403` errors, so tests could not be executed here (blocked).
- Updated the test file to assert the new empty-scan dedupe behavior and verified the test changes compile locally in-tree, but full automated test execution was not possible due to the dependency resolution issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a336c297400832f9ad49a9dd56c9552)