### PR TITLE
Avoid aborting leader-election loop on firehose failures (add voluntary stepDown)

### DIFF
--- a/apps/firehose-service/src/index.ts
+++ b/apps/firehose-service/src/index.ts
@@ -16,7 +16,7 @@ import { closeCacheInvalidationPublisher } from './lib/cache-invalidation'
 import { fetchSiteRecord, handleSiteCreateOrUpdate, listSiteRecordsForDid } from './lib/cache-writer'
 import { closeDatabase, getSiteCache, listAllKnownDids } from './lib/db'
 import { getActiveService, getCurrentSeq, getFirehoseHealth, startFirehose, stopFirehose } from './lib/firehose'
-import { closeLeaderRedis, getLeaderInfo, releaseLeadership, runLeaderElection, saveCursor } from './lib/leader'
+import { closeLeaderRedis, getLeaderInfo, runLeaderElection, saveCursor } from './lib/leader'
 import { startRevalidateWorker, stopRevalidateWorker } from './lib/revalidate-worker'
 import { storage } from './lib/storage'
 
@@ -264,10 +264,10 @@ async function main() {
 
 		// Run election loop (non-blocking)
 		runLeaderElection(
-			(cursor) =>
+			(cursor, stepDown) =>
 				startFirehose(cursor, () => {
 					logger.warn('Firehose failed 3 times, stepping down from leadership')
-					releaseLeadership().finally(() => leaderAbortController?.abort())
+					stepDown()
 				}),
 			() => stopFirehose(),
 			leaderAbortController.signal,

--- a/apps/firehose-service/src/lib/leader.ts
+++ b/apps/firehose-service/src/lib/leader.ts
@@ -120,7 +120,7 @@ function sleep(ms: number): Promise<void> {
  * aborted via the signal.
  */
 export async function runLeaderElection(
-	onBecomeLeader: (cursor: number | undefined) => void,
+	onBecomeLeader: (cursor: number | undefined, stepDown: () => void) => void,
 	onLoseLeadership: () => void,
 	signal: AbortSignal,
 	initialService: string,
@@ -135,6 +135,17 @@ export async function runLeaderElection(
 	const clearRenewal = () => {
 		if (renewalTimer) clearTimeout(renewalTimer)
 		renewalTimer = null
+	}
+
+	const stepDown = () => {
+		if (!isLeader) return
+
+		logger.warn('[Leader] Stepping down voluntarily')
+		clearRenewal()
+		isLeader = false
+		renewalFailures = 0
+		onLoseLeadership()
+		releaseLeadership().catch((err) => logger.warn('[Leader] Failed to release leadership while stepping down', err))
 	}
 
 	signal.addEventListener('abort', () => {
@@ -189,7 +200,7 @@ export async function runLeaderElection(
 			renewalFailures = 0
 			const cursor = await readCursor(initialService)
 			logger.info(`[Leader] Won leadership, cursor for ${initialService}: ${cursor ?? 'none (starting from head)'}`)
-			onBecomeLeader(cursor)
+			onBecomeLeader(cursor, stepDown)
 			scheduleRenew()
 		}
 


### PR DESCRIPTION
### Motivation
- Repeated firehose `onError` calls could previously trigger an offline callback that released leadership and aborted the shared `leaderAbortController`, which permanently stopped the leader-election loop in-process instead of letting the instance return to standby polling. 
- The change aims to allow a leader to step down cleanly on repeated failures without aborting the global election signal so the process can continue participating as a standby.

### Description
- Add a `stepDown` callback to `runLeaderElection` and pass it into the `onBecomeLeader` callback so a leader can voluntarily release leadership without aborting the election `signal`. 
- Implement `stepDown` to clear renewal timers, call `onLoseLeadership()`, and release the Redis leader key via `releaseLeadership()` while keeping the election loop alive to continue standby polling. 
- Update `apps/firehose-service/src/index.ts` to call the provided `stepDown()` from the firehose offline handler instead of calling `releaseLeadership().finally(() => leaderAbortController?.abort())`, preserving the step-down behavior without aborting the controller.

### Testing
- Ran `git diff --check` which returned no whitespace or diff errors. 
- Attempted `bun run check` (which executes `bun tsc --noEmit`) and it failed due to the local environment reporting `error: Script not found "tsc"`. 
- Attempted `bunx biome check apps/firehose-service/src/index.ts apps/firehose-service/src/lib/leader.ts` and it failed while resolving `biome` due to an npm registry `403`, so type/lint checks could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33702b73d0832fbd41967be41c10e6)