### PR TITLE
Enforce ownership check on custom-domain verification

### DIFF
--- a/apps/main-app/src/routes/domain.ts
+++ b/apps/main-app/src/routes/domain.ts
@@ -264,6 +264,11 @@ export const domainRoutes = (client: NodeOAuthClient, cookieSecret: string) =>
 					throw new Error('Domain not found')
 				}
 
+				if (domainInfo.did !== auth.did) {
+					set.status = 403
+					throw new Error('Unauthorized: You do not own this domain')
+				}
+
 				// Verify DNS records (TXT + CNAME)
 				logger.debug(`[Domain] Verifying custom domain: ${domainInfo.domain}`)
 				const result = await verifyCustomDomain(domainInfo.domain, auth.did, id)


### PR DESCRIPTION
### Motivation
- Close an IDOR where an authenticated user could call `POST /api/domain/custom/verify` with another tenant's custom-domain ID and change its verification state.

### Description
- Add an ownership check in `POST /api/domain/custom/verify` that returns `403` when `domainInfo.did !== auth.did`, preventing DNS verification and `updateCustomDomainVerification` from running for non-owners.

### Testing
- Ran `git diff --check` which passed. 
- Ran `bun run check` / typecheck which failed in this environment because `node_modules`/`tsc` are not installed, so full typechecks could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a36c80d1a68832f85dfae986c3b2c95)