### PR TITLE
Harden webhook delivery URL validation to mitigate SSRF

### DIFF
--- a/apps/webhook-service/src/lib/delivery.ts
+++ b/apps/webhook-service/src/lib/delivery.ts
@@ -5,6 +5,7 @@ import type { WebhookEntry } from './db'
 import { getWebhookSecretToken, insertEventLog } from './db'
 import type { EventKind } from './matcher'
 import { publishWebhookEvent } from './redis'
+import { assertSafeWebhookUrl } from './webhook-url'
 
 const logger = createLogger('webhook-service:delivery')
 
@@ -36,10 +37,13 @@ async function attempt(url: string, body: string, signature?: string): Promise<v
 	}
 	if (signature) headers['X-Webhook-Signature'] = signature
 
+	await assertSafeWebhookUrl(url)
+
 	const res = await fetch(url, {
 		method: 'POST',
 		headers,
 		body,
+		redirect: 'error',
 		signal: AbortSignal.timeout(config.deliveryTimeoutMs),
 	})
 

--- a/apps/webhook-service/src/lib/firehose.ts
+++ b/apps/webhook-service/src/lib/firehose.ts
@@ -12,6 +12,7 @@ import {
 import { deliverWebhook } from './delivery'
 import { JetstreamClient, type JetstreamEvent } from './jetstream'
 import { matchWebhooks } from './matcher'
+import { assertSafeWebhookUrlSyntax } from './webhook-url'
 import { getCached, invalidate, setCached } from './registry'
 
 const logger = createLogger('webhook-service:firehose')
@@ -172,6 +173,12 @@ async function handleWhRecord(op: string, did: string, rkey: string, record: unk
 		const wh = record as WhRecord
 		if (!wh.scope?.aturi || !wh.url) {
 			logger.error(`[wh] Skipping ${did}/${rkey} — invalid record`, { record })
+			return
+		}
+		try {
+			assertSafeWebhookUrlSyntax(wh.url)
+		} catch (err) {
+			logger.error(`[wh] Skipping ${did}/${rkey} — unsafe webhook URL`, { err })
 			return
 		}
 		logger.info(`[wh] scope=${wh.scope.aturi} url=${wh.url} enabled=${wh.enabled ?? true}`)

--- a/apps/webhook-service/src/lib/webhook-url.test.ts
+++ b/apps/webhook-service/src/lib/webhook-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test'
+import { assertSafeWebhookUrl, assertSafeWebhookUrlSyntax } from './webhook-url'
+
+describe('webhook URL validation', () => {
+	test('requires HTTPS URLs without credentials', () => {
+		expect(() => assertSafeWebhookUrlSyntax('http://example.com/webhook')).toThrow('HTTPS')
+		expect(() => assertSafeWebhookUrlSyntax('https://user:pass@example.com/webhook')).toThrow('credentials')
+		expect(() => assertSafeWebhookUrlSyntax('https://example.com/webhook')).not.toThrow()
+	})
+
+	test('blocks direct private and metadata IP destinations', async () => {
+		await expect(assertSafeWebhookUrl('https://127.0.0.1/webhook')).rejects.toThrow('private address')
+		await expect(assertSafeWebhookUrl('https://169.254.169.254/latest/meta-data')).rejects.toThrow('private address')
+		await expect(assertSafeWebhookUrl('https://[::1]/webhook')).rejects.toThrow('private address')
+	})
+})

--- a/apps/webhook-service/src/lib/webhook-url.ts
+++ b/apps/webhook-service/src/lib/webhook-url.ts
@@ -1,0 +1,96 @@
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+
+const MAX_WEBHOOK_URL_LENGTH = 2048
+
+function isPrivateIp(ip: string): boolean {
+	const version = isIP(ip)
+	if (version === 4) {
+		const [a = 0, b = 0] = ip.split('.').map((part) => Number.parseInt(part, 10))
+		return (
+			a === 0 ||
+			a === 10 ||
+			a === 127 ||
+			(a === 169 && b === 254) ||
+			(a === 172 && b >= 16 && b <= 31) ||
+			(a === 192 && b === 168) ||
+			a >= 224
+		)
+	}
+
+	if (version === 6) {
+		const normalized = ip.toLowerCase()
+		return (
+			normalized === '::' ||
+			normalized === '::1' ||
+			normalized.startsWith('fc') ||
+			normalized.startsWith('fd') ||
+			normalized.startsWith('fe8') ||
+			normalized.startsWith('fe9') ||
+			normalized.startsWith('fea') ||
+			normalized.startsWith('feb') ||
+			normalized.startsWith('ff') ||
+			normalized.startsWith('::ffff:127.') ||
+			normalized.startsWith('::ffff:10.') ||
+			normalized.startsWith('::ffff:169.254.') ||
+			normalized.startsWith('::ffff:192.168.') ||
+			/^::ffff:172\.(1[6-9]|2\d|3[01])\./.test(normalized)
+		)
+	}
+
+	return true
+}
+
+function parseWebhookUrl(url: string): URL {
+	if (url.length > MAX_WEBHOOK_URL_LENGTH) {
+		throw new Error('Webhook URL is too long')
+	}
+
+	let parsed: URL
+	try {
+		parsed = new URL(url)
+	} catch (_err) {
+		throw new Error('Webhook URL is invalid')
+	}
+
+	if (parsed.protocol !== 'https:') {
+		throw new Error('Webhook URL must use HTTPS')
+	}
+
+	if (parsed.username || parsed.password) {
+		throw new Error('Webhook URL must not contain credentials')
+	}
+
+	return parsed
+}
+
+export async function assertSafeWebhookUrl(url: string): Promise<void> {
+	const parsed = parseWebhookUrl(url)
+	const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '')
+
+	if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
+		throw new Error('Webhook URL host is not allowed')
+	}
+
+	if (isIP(hostname)) {
+		if (isPrivateIp(hostname)) {
+			throw new Error('Webhook URL resolves to a private address')
+		}
+		return
+	}
+
+	const addresses = await lookup(hostname, { all: true, verbatim: true })
+	if (addresses.length === 0) {
+		throw new Error('Webhook URL host did not resolve')
+	}
+
+	for (const { address } of addresses) {
+		if (isPrivateIp(address)) {
+			throw new Error('Webhook URL resolves to a private address')
+		}
+	}
+}
+
+export function assertSafeWebhookUrlSyntax(url: string): void {
+	parseWebhookUrl(url)
+}


### PR DESCRIPTION
### Motivation
- The webhook service accepted attacker-controlled `url` values from public firehose records and passed them directly to `fetch()`, enabling blind SSRF to localhost, metadata endpoints, and private IPs.
- Minimal schema/syntax checks allowed unsafe URLs to be persisted and retried, increasing impact.

### Description
- Added `apps/webhook-service/src/lib/webhook-url.ts` implementing `assertSafeWebhookUrl` and `assertSafeWebhookUrlSyntax` that require `https:`, reject credentials, normalize IPv6 hostnames, block localhost/private/link-local/multicast ranges, and perform DNS resolution checks.
- Updated `apps/webhook-service/src/lib/delivery.ts` to call `assertSafeWebhookUrl(url)` before issuing `fetch()` and set `redirect: 'error'` to prevent public endpoints from redirecting deliveries to internal targets.
- Updated `apps/webhook-service/src/lib/firehose.ts` to run `assertSafeWebhookUrlSyntax(wh.url)` before calling `upsertWebhookRecord`, preventing obviously unsafe records from being stored.
- Added tests in `apps/webhook-service/src/lib/webhook-url.test.ts` covering HTTPS/credential syntax and blocking of loopback/metadata IP destinations.

### Testing
- Ran `bun test apps/webhook-service/src/lib/webhook-url.test.ts` and the new tests passed (2 passed, 0 failed).
- Ran project type check (`bun run --cwd apps/webhook-service check` / `tsc`) which could not fully complete in this environment due to an existing TypeScript `baseUrl` deprecation/configuration issue and broader ambient type errors, so full type-check was not verified here. 
- Linting (`biome`/project lint) could not be executed in this environment because the tool is not available, so lint checks were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33786664a0832f8ef519b81de15e90)