### PR TITLE
Cap hosting updating-site state to prevent unbounded memory growth

### DIFF
--- a/apps/hosting-service/src/lib/cache-invalidation.test.ts
+++ b/apps/hosting-service/src/lib/cache-invalidation.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from 'bun:test'
 import {
 	clearSiteUpdating,
 	compareStreamIds,
+	getUpdatingSiteCountForTests,
 	isSiteUpdating,
 	markSiteUpdating,
 	parseCacheInvalidationMessage,
@@ -37,6 +38,38 @@ describe('cache invalidation updating state', () => {
 
 		expect(clearSiteUpdating(DID, RKEY)).toBe(true)
 		expect(isSiteUpdating(DID, RKEY)).toBe(false)
+	})
+
+	test('marking a new site prunes expired updating entries that were never requested', () => {
+		const originalNow = Date.now
+		let now = 1_000_000
+		Date.now = () => now
+
+		try {
+			markSiteUpdating(DID, 'expired-a')
+			markSiteUpdating(DID, 'expired-b')
+
+			now += 10 * 60 * 1000 + 1
+			markSiteUpdating(DID, 'active')
+
+			expect(getUpdatingSiteCountForTests()).toBe(1)
+			expect(isSiteUpdating(DID, 'active')).toBe(true)
+			expect(isSiteUpdating(DID, 'expired-a')).toBe(false)
+			expect(isSiteUpdating(DID, 'expired-b')).toBe(false)
+		} finally {
+			Date.now = originalNow
+		}
+	})
+
+	test('updating state is capped even when entries have not expired', () => {
+		for (let i = 0; i < 10_005; i++) {
+			markSiteUpdating(DID, `site-${i}`)
+		}
+
+		expect(getUpdatingSiteCountForTests()).toBe(10_000)
+		expect(isSiteUpdating(DID, 'site-0')).toBe(false)
+		expect(isSiteUpdating(DID, 'site-5')).toBe(true)
+		expect(isSiteUpdating(DID, 'site-10004')).toBe(true)
 	})
 
 	test('message parsing preserves token', () => {

--- a/apps/hosting-service/src/lib/cache-invalidation.ts
+++ b/apps/hosting-service/src/lib/cache-invalidation.ts
@@ -44,7 +44,24 @@ export interface CacheInvalidationMessage {
 // Maps `${did}/${rkey}` → current update token and timestamp.
 // Used to show an "updating" page instead of serving stale files.
 const UPDATING_TTL_MS = 10 * 60 * 1000 // 10 minutes safety timeout
+const MAX_UPDATING_SITES = parsePositiveInt(process.env.WISP_MAX_UPDATING_SITES, 10_000)
 const updatingSites = new Map<string, { since: number; token?: string }>()
+
+function pruneExpiredUpdatingSites(now = Date.now()): void {
+	for (const [key, state] of updatingSites) {
+		if (now - state.since > UPDATING_TTL_MS) {
+			updatingSites.delete(key)
+		}
+	}
+}
+
+function enforceUpdatingSitesLimit(): void {
+	while (updatingSites.size > MAX_UPDATING_SITES) {
+		const oldestKey = updatingSites.keys().next().value
+		if (oldestKey === undefined) return
+		updatingSites.delete(oldestKey)
+	}
+}
 
 export function isSiteUpdating(did: string, rkey: string): boolean {
 	const key = `${did}/${rkey}`
@@ -59,7 +76,13 @@ export function isSiteUpdating(did: string, rkey: string): boolean {
 }
 
 export function markSiteUpdating(did: string, rkey: string, token?: string): void {
-	updatingSites.set(`${did}/${rkey}`, { since: Date.now(), token })
+	const now = Date.now()
+	const key = `${did}/${rkey}`
+	pruneExpiredUpdatingSites(now)
+	// Refresh insertion order so the cap evicts the oldest active update.
+	updatingSites.delete(key)
+	updatingSites.set(key, { since: now, token })
+	enforceUpdatingSitesLimit()
 }
 
 export function clearSiteUpdating(did: string, rkey: string, token?: string): boolean {
@@ -79,6 +102,10 @@ export function clearSiteUpdating(did: string, rkey: string, token?: string): bo
 
 export function resetUpdatingSitesForTests(): void {
 	updatingSites.clear()
+}
+
+export function getUpdatingSiteCountForTests(): number {
+	return updatingSites.size
 }
 
 let subscriber: Redis | null = null


### PR DESCRIPTION
### Motivation
- The hosting-service kept `updating` markers in a process-local Map with only opportunistic per-key TTL cleanup, allowing attackers to publish many distinct `updating` messages and exhaust memory or force persistent 503s. 
- The firehose publishes `updating` before potentially-failing downloads and only publishes a clearing `update` on success, so failures can leave entries permanently unless the exact site is requested.
- A deterministic, lightweight server-side mitigation is required to prevent unbounded accumulation while preserving the existing behavior of showing an "updating" page for legitimately-updating sites.

### Description
- Add a configurable hard cap `WISP_MAX_UPDATING_SITES` (default `10000`) and enforce it by evicting the oldest tracked entry when exceeded in `apps/hosting-service/src/lib/cache-invalidation.ts`.
- Prune expired `updating` entries during `markSiteUpdating()` so never-requested stale entries are removed opportunistically on new marks.
- Keep per-site token/version semantics intact and add `getUpdatingSiteCountForTests()` and tests that exercise expiry-pruning and the cap in `apps/hosting-service/src/lib/cache-invalidation.test.ts`.
- Changes are localized to the hosting cache invalidation code and unit tests; no behavioral change to the firehose invalidation publication order was made.

### Testing
- Ran `git diff --check` and committed the changes locally (`Cap hosting updating site state`).
- Added unit tests in `apps/hosting-service/src/lib/cache-invalidation.test.ts` covering expiry pruning and the size cap, but running `bun test` failed due to missing runtime dependencies (`ioredis`) in this environment so tests could not complete.
- Attempted dependency installation (`bun install`) and `biome` checks, but both were blocked by the environment's npm registry returning `403`, preventing full automated test execution here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a337a3b20fc832fb98d46616a028cb8)