### PR TITLE
Reject unsafe redirect splat patterns

### DIFF
--- a/packages/@wispplace/fs-utils/src/redirects.test.ts
+++ b/packages/@wispplace/fs-utils/src/redirects.test.ts
@@ -51,6 +51,18 @@ describe('parseRedirectsFile', () => {
 		expect(rules[0]?.to).toBe('/blog/:splat')
 	})
 
+	it('should reject splats that can cause regex backtracking', () => {
+		const content = `
+/safe/* /target/:splat
+/nested/*/suffix /target
+/*/*/*/*/*/*/*/*/x /target
+`
+		const rules = parseRedirectsFile(content)
+
+		expect(rules).toHaveLength(1)
+		expect(rules[0]?.from).toBe('/safe/*')
+	})
+
 	it('should parse placeholder redirects', () => {
 		const content = `/blog/:year/:month/:day /posts/:year-:month-:day`
 		const rules = parseRedirectsFile(content)

--- a/packages/@wispplace/fs-utils/src/redirects.ts
+++ b/packages/@wispplace/fs-utils/src/redirects.ts
@@ -193,6 +193,10 @@ function convertPathToRegex(pattern: string): { pattern: RegExp; params: string[
 	let regexStr = '^'
 
 	const pathPart = pattern.split('?')[0] || pattern
+	const splatCount = (pathPart.match(/\*/g) || []).length
+	if (splatCount > 1 || (splatCount === 1 && !pathPart.endsWith('*'))) {
+		throw new Error('Redirect splats must appear at most once and at the end of the path')
+	}
 
 	let escaped = pathPart.replace(/[.+^${}()|[\]\\]/g, '\\$&')
 


### PR DESCRIPTION
## Summary

Reject redirect sources with multiple splats or a non-terminal splat before compiling them into regular expressions.

## Why

Public `_redirects` files are expected in Wisp. The security boundary is ensuring untrusted public routing data cannot create pathological request-time regex work.

Finding: https://chatgpt.com/codex/cloud/security/findings/2e7ef865031481918d2a0003bdda10d3

## Impact

Valid terminal-splat redirects continue to work. Ambiguous unsafe splat patterns are ignored.

## Root cause

The parser accepted arbitrary splat placement and translated every splat to a greedy capture.

## Verification

- 24 redirect tests pass
- hosting-service production build passes
- `bun check` reaches the pre-existing unrelated `releaseLeadership` error in firehose-service