### PR TITLE
Verify CLI binaries before CI execution

### DIFF
--- a/apps/main-app/public/editor/tabs/CLITab.tsx
+++ b/apps/main-app/public/editor/tabs/CLITab.tsx
@@ -33,6 +33,8 @@ const BINARIES = [
 	},
 ] as const
 
+const LINUX_X86_64_SHA256 = BINARIES.find(({ filename }) => filename === 'wisp-cli-x86_64-linux')?.sha256
+
 const LINKS = [
 	{ label: 'Docs', href: 'https://docs.wisp.place/cli' },
 	{
@@ -117,6 +119,9 @@ export const CLITab = memo(function CLITab() {
 							</a>
 						))}
 					</div>
+					<p className="text-[10px] text-muted-foreground mt-2">
+						Verify the displayed SHA-256 checksum before running a downloaded binary.
+					</p>
 				</div>
 
 				{/* Commands */}
@@ -204,7 +209,8 @@ export const CLITab = memo(function CLITab() {
 									code={`steps:
   - name: deploy to wisp
     command: |
-      curl ${BASE_URL}/wisp-cli-x86_64-linux -o wisp-cli
+      curl -fL ${BASE_URL}/wisp-cli-x86_64-linux -o wisp-cli
+      printf '%s  %s\n' '${LINUX_X86_64_SHA256}' wisp-cli | sha256sum -c -
       chmod +x wisp-cli
       ./wisp-cli deploy "$WISP_HANDLE" \\
         --path "$SITE_PATH" \\
@@ -238,7 +244,8 @@ steps:
       bun node_modules/.bin/vite build
   - name: deploy
     command: |
-      curl ${BASE_URL}/wisp-cli-x86_64-linux -o wisp-cli
+      curl -fL ${BASE_URL}/wisp-cli-x86_64-linux -o wisp-cli
+      printf '%s  %s\n' '${LINUX_X86_64_SHA256}' wisp-cli | sha256sum -c -
       chmod +x wisp-cli
       ./wisp-cli deploy "$WISP_HANDLE" \\
         --path "$SITE_PATH" \\


### PR DESCRIPTION
## Summary

Make generated CI snippets download with `curl -fL` and verify the displayed Linux SHA-256 checksum before making the Wisp CLI executable.

## Why

The current snippets execute a downloaded binary directly. This adds an immediate integrity check while a stronger immutable release channel is designed.

Finding: https://chatgpt.com/codex/cloud/security/findings/b28d1ae1b1648191a0571801cbba905c

## Impact

CI fails closed when the downloaded bytes do not match the checksum shown by Wisp.

## Root cause

The generated examples skipped transport failure handling and artifact verification.

## Verification

- main-app production build passes
- `bun check` reaches the pre-existing unrelated `releaseLeadership` error in firehose-service