### PR TITLE
Bound gzip decompression

### DIFF
--- a/apps/firehose-service/src/lib/cache-writer.ts
+++ b/apps/firehose-service/src/lib/cache-writer.ts
@@ -3,10 +3,15 @@
  * Handles incremental updates by comparing CIDs
  */
 
-import { gunzipSync } from 'node:zlib'
 import { extractBlobCid, getPdsForDid } from '@wispplace/atproto-utils'
-import { shouldCompressMimeType } from '@wispplace/atproto-utils/compression'
-import { MAX_BLOB_SIZE, MAX_FILE_COUNT, MAX_SITE_SIZE, MAX_SITE_SIZE_SUPPORTER } from '@wispplace/constants'
+import { decompressFile, shouldCompressMimeType } from '@wispplace/atproto-utils/compression'
+import {
+	MAX_BLOB_SIZE,
+	MAX_DECOMPRESSED_BLOB_SIZE,
+	MAX_FILE_COUNT,
+	MAX_SITE_SIZE,
+	MAX_SITE_SIZE_SUPPORTER,
+} from '@wispplace/constants'
 import { collectFileCidsFromEntries, countFilesInDirectory, normalizeFileCids } from '@wispplace/fs-utils'
 import { isHtmlContent, rewriteHtmlPaths } from '@wispplace/fs-utils/html-rewriter'
 import type { Directory, Entry, File, Record as WispFsRecord } from '@wispplace/lexicons/types/place/wisp/fs'
@@ -518,7 +523,7 @@ async function downloadAndWriteBlob(did: string, rkey: string, file: FileInfo, p
 		content[1] === 0x8b
 	) {
 		try {
-			content = gunzipSync(content)
+			content = decompressFile(content, MAX_DECOMPRESSED_BLOB_SIZE)
 			encoding = undefined
 		} catch (error) {
 			logger.error(`Failed to decompress ${file.path}, storing gzipped`, error)
@@ -529,7 +534,7 @@ async function downloadAndWriteBlob(did: string, rkey: string, file: FileInfo, p
 		if (decoded && decoded.length >= 2 && decoded[0] === 0x1f && decoded[1] === 0x8b) {
 			logger.warn(`Decoded base64+gzip fallback for ${file.path}`)
 			try {
-				content = gunzipSync(decoded)
+				content = decompressFile(decoded, MAX_DECOMPRESSED_BLOB_SIZE)
 				encoding = undefined
 			} catch (error) {
 				logger.error(`Failed to decompress base64+gzip fallback for ${file.path}, storing gzipped`, error)
@@ -567,7 +572,7 @@ async function downloadAndWriteBlob(did: string, rkey: string, file: FileInfo, p
 			let rewriteSource = content
 			if (encoding === 'gzip' && content.length >= 2 && content[0] === 0x1f && content[1] === 0x8b) {
 				try {
-					rewriteSource = gunzipSync(content)
+					rewriteSource = decompressFile(content, MAX_DECOMPRESSED_BLOB_SIZE)
 				} catch (error) {
 					logger.error(`Failed to decompress ${file.path} for rewrite, using raw content`, error)
 				}

--- a/apps/hosting-service/src/lib/file-serving.ts
+++ b/apps/hosting-service/src/lib/file-serving.ts
@@ -3,8 +3,9 @@
  * Handles file retrieval, caching, redirects, and HTML rewriting
  */
 
-import { gunzipSync, gzipSync } from 'node:zlib'
-import { shouldCompressMimeType } from '@wispplace/atproto-utils/compression'
+import { gzipSync } from 'node:zlib'
+import { decompressFile, shouldCompressMimeType } from '@wispplace/atproto-utils/compression'
+import { MAX_DECOMPRESSED_BLOB_SIZE } from '@wispplace/constants'
 import { normalizeFileCids } from '@wispplace/fs-utils'
 import { isHtmlContent, rewriteHtmlPaths } from '@wispplace/fs-utils/html-rewriter'
 import type { Record as WispSettings } from '@wispplace/lexicons/types/place/wisp/settings'
@@ -380,7 +381,7 @@ function buildResponseFromStorageResult(
 
 		if (!clientAcceptsGzip || !shouldServeCompressed) {
 			if (hasGzipMagic) {
-				const decompressed = gunzipSync(content)
+				const decompressed = decompressFile(content, MAX_DECOMPRESSED_BLOB_SIZE)
 				applyCustomHeaders(headers, filePath, settings)
 				return new Response(decompressed, { headers })
 			}
@@ -419,7 +420,7 @@ async function buildRewrittenHtmlResponse(
 		let decoded = content
 		if (meta?.encoding === 'gzip') {
 			if (hasGzipMagic) {
-				decoded = gunzipSync(content)
+				decoded = decompressFile(content, MAX_DECOMPRESSED_BLOB_SIZE)
 			} else {
 				logger.warn(`File marked as gzipped but lacks magic bytes, serving original`, { filePath })
 				applyCustomHeaders(headers, filePath, settings)
@@ -427,7 +428,7 @@ async function buildRewrittenHtmlResponse(
 			}
 		} else if (hasGzipMagic && shouldCompressMimeType(mimeType)) {
 			// Heuristic: treat as gzipped text content even if encoding metadata is missing
-			decoded = gunzipSync(content)
+			decoded = decompressFile(content, MAX_DECOMPRESSED_BLOB_SIZE)
 		}
 
 		const htmlString = new TextDecoder().decode(decoded)

--- a/apps/hosting-service/src/lib/on-demand-cache.ts
+++ b/apps/hosting-service/src/lib/on-demand-cache.ts
@@ -9,10 +9,15 @@
  * so the firehose-service backfills S3 (cold tier).
  */
 
-import { gunzipSync } from 'node:zlib'
 import { extractBlobCid, getPdsForDid } from '@wispplace/atproto-utils'
-import { shouldCompressMimeType } from '@wispplace/atproto-utils/compression'
-import { MAX_BLOB_SIZE, MAX_FILE_COUNT, MAX_SITE_SIZE, MAX_SITE_SIZE_SUPPORTER } from '@wispplace/constants'
+import { decompressFile, shouldCompressMimeType } from '@wispplace/atproto-utils/compression'
+import {
+	MAX_BLOB_SIZE,
+	MAX_DECOMPRESSED_BLOB_SIZE,
+	MAX_FILE_COUNT,
+	MAX_SITE_SIZE,
+	MAX_SITE_SIZE_SUPPORTER,
+} from '@wispplace/constants'
 import { collectFileCidsFromEntries, countFilesInDirectory } from '@wispplace/fs-utils'
 import type { Directory, Entry, File, Record as WispFsRecord } from '@wispplace/lexicons/types/place/wisp/fs'
 import { createLogger } from '@wispplace/observability'
@@ -225,12 +230,7 @@ function validateEntryNames(entries: Entry[], pathPrefix: string = ''): void {
 
 function isSafeEntryName(name: string): boolean {
 	return (
-		name !== '' &&
-		name !== '.' &&
-		name !== '..' &&
-		!name.includes('/') &&
-		!name.includes('\\') &&
-		!name.includes('\0')
+		name !== '' && name !== '.' && name !== '..' && !name.includes('/') && !name.includes('\\') && !name.includes('\0')
 	)
 }
 
@@ -311,7 +311,7 @@ async function downloadAndWriteBlob(did: string, rkey: string, file: FileInfo, p
 		content[1] === 0x8b
 	) {
 		try {
-			content = gunzipSync(content)
+			content = decompressFile(content, MAX_DECOMPRESSED_BLOB_SIZE)
 			encoding = undefined
 		} catch (error) {
 			logger.warn(`Failed to decompress ${file.path}, storing gzipped`, { did, rkey, error })
@@ -322,7 +322,7 @@ async function downloadAndWriteBlob(did: string, rkey: string, file: FileInfo, p
 		if (decoded && decoded.length >= 2 && decoded[0] === 0x1f && decoded[1] === 0x8b) {
 			logger.warn(`Decoded base64+gzip fallback for ${file.path}`, { did, rkey })
 			try {
-				content = gunzipSync(decoded)
+				content = decompressFile(decoded, MAX_DECOMPRESSED_BLOB_SIZE)
 				encoding = undefined
 			} catch (error) {
 				logger.warn(`Failed to decompress base64+gzip fallback for ${file.path}, storing gzipped`, { did, rkey, error })

--- a/cli/commands/pull.ts
+++ b/cli/commands/pull.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { gunzipSync } from 'node:zlib'
 import { extractBlobCid, getPdsForDid, resolveDid } from '@wispplace/atproto-utils'
+import { decompressFile } from '@wispplace/atproto-utils/compression'
+import { MAX_DECOMPRESSED_BLOB_SIZE } from '@wispplace/constants'
 import { sanitizePath } from '@wispplace/fs-utils'
 import type { Directory, Entry, File, Record as FsRecord } from '@wispplace/lexicons/types/place/wisp/fs'
 import type { Record as SubfsRecord } from '@wispplace/lexicons/types/place/wisp/subfs'
@@ -225,7 +226,7 @@ async function downloadBlob(pdsEndpoint: string, did: string, file: FileToDownlo
 	// Decompress gzip
 	if (file.encoding === 'gzip' && content.length >= 2 && content[0] === 0x1f && content[1] === 0x8b) {
 		try {
-			content = gunzipSync(content)
+			content = decompressFile(content, MAX_DECOMPRESSED_BLOB_SIZE)
 		} catch {
 			// Keep original content if decompression fails
 		}

--- a/packages/@wispplace/atproto-utils/src/compression.test.ts
+++ b/packages/@wispplace/atproto-utils/src/compression.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test'
+import { gzipSync } from 'node:zlib'
+import { decompressFile } from './compression'
+
+describe('decompressFile', () => {
+	test('decompresses content within the configured limit', () => {
+		const compressed = gzipSync(Buffer.from('hello'))
+		expect(decompressFile(compressed, 1024).toString()).toBe('hello')
+	})
+
+	test('rejects content that expands past the configured limit', () => {
+		const compressed = gzipSync(Buffer.alloc(4096, 0x61))
+		expect(() => decompressFile(compressed, 1024)).toThrow()
+	})
+})

--- a/packages/@wispplace/atproto-utils/src/compression.ts
+++ b/packages/@wispplace/atproto-utils/src/compression.ts
@@ -1,4 +1,4 @@
-import { gzipSync } from 'node:zlib'
+import { gunzipSync, gzipSync } from 'node:zlib'
 import { charsets } from 'mime-types'
 
 /**
@@ -101,4 +101,16 @@ export function compressFile(content: Buffer): Buffer {
 	return gzipSync(content, {
 		level: 9,
 	})
+}
+
+/**
+ * Decompress gzip content without allowing an attacker-controlled blob to grow
+ * beyond the caller's accepted file-size limit.
+ */
+export function decompressFile(content: Uint8Array, maxOutputLength: number): Buffer<ArrayBuffer> {
+	if (!Number.isSafeInteger(maxOutputLength) || maxOutputLength <= 0) {
+		throw new Error('maxOutputLength must be a positive safe integer')
+	}
+
+	return Buffer.from(gunzipSync(content, { maxOutputLength }))
 }

--- a/packages/@wispplace/constants/src/index.ts
+++ b/packages/@wispplace/constants/src/index.ts
@@ -25,6 +25,7 @@ export const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 export const FETCH_TIMEOUT_MS = 30000 // 30 seconds
 export const MAX_JSON_SIZE = 10 * 1024 * 1024 // 10MB
 export const MAX_BLOB_SIZE = MAX_FILE_SIZE // Use file size limit
+export const MAX_DECOMPRESSED_BLOB_SIZE = MAX_FILE_SIZE
 
 // Directory limits (AT Protocol lexicon constraints)
 export const MAX_ENTRIES_PER_DIRECTORY = 500


### PR DESCRIPTION
## Summary

Centralize gzip expansion and cap decompressed output at Wisp's per-file size limit across firehose, hosting, on-demand caching, and CLI pull paths.

## Why

Compressed blobs are public by design. The security concern is unbounded expansion of attacker-controlled bytes in service memory.

Findings:
- https://chatgpt.com/codex/cloud/security/findings/331e9f5fd2888191ae0d2489193f1839
- https://chatgpt.com/codex/cloud/security/findings/c84d3fd3dfdc8191b665dcc328a9d0cb
- https://chatgpt.com/codex/cloud/security/findings/1ca4bb84b0748191b5d0c80b90ccdc97

## Impact

A single compressed file cannot expand past `MAX_FILE_SIZE`. Aggregate expanded-site accounting remains a separate design follow-up.

## Root cause

Several paths called `gunzipSync` without `maxOutputLength`.

## Verification

- 2 decompression tests pass
- main-app and hosting-service production builds pass
- firehose-service production image builds
- CLI binary builds
- `bun check` reaches the pre-existing unrelated `releaseLeadership` error in firehose-service