### PR TITLE
Block shared-origin service worker scope headers

### DIFF
--- a/apps/hosting-service/src/lib/file-serving.ts
+++ b/apps/hosting-service/src/lib/file-serving.ts
@@ -338,6 +338,7 @@ function buildResponseFromStorageResult(
 	filePath: string,
 	settings: WispSettings | null,
 	requestHeaders?: Record<string, string>,
+	sharedOrigin = false,
 ): Response {
 	const content = Buffer.from(result.data)
 	const meta = result.metadata.customMetadata as { encoding?: string; mimeType?: string } | undefined
@@ -381,18 +382,18 @@ function buildResponseFromStorageResult(
 		if (!clientAcceptsGzip || !shouldServeCompressed) {
 			if (hasGzipMagic) {
 				const decompressed = gunzipSync(content)
-				applyCustomHeaders(headers, filePath, settings)
+				applyCustomHeaders(headers, filePath, settings, { sharedOrigin })
 				return new Response(decompressed, { headers })
 			}
 			logger.warn(`File marked as gzipped but lacks magic bytes, serving as-is`, { filePath })
-			applyCustomHeaders(headers, filePath, settings)
+			applyCustomHeaders(headers, filePath, settings, { sharedOrigin })
 			return new Response(content, { headers })
 		}
 
 		headers['Content-Encoding'] = 'gzip'
 	}
 
-	applyCustomHeaders(headers, filePath, settings)
+	applyCustomHeaders(headers, filePath, settings, { sharedOrigin })
 	return new Response(content, { headers })
 }
 
@@ -402,6 +403,7 @@ async function buildRewrittenHtmlResponse(
 	basePath: string,
 	settings: WispSettings | null,
 	requestHeaders?: Record<string, string>,
+	sharedOrigin = false,
 ): Promise<Response> {
 	try {
 		const content = Buffer.from(result.data)
@@ -422,7 +424,7 @@ async function buildRewrittenHtmlResponse(
 				decoded = gunzipSync(content)
 			} else {
 				logger.warn(`File marked as gzipped but lacks magic bytes, serving original`, { filePath })
-				applyCustomHeaders(headers, filePath, settings)
+				applyCustomHeaders(headers, filePath, settings, { sharedOrigin })
 				return new Response(content, { headers })
 			}
 		} else if (hasGzipMagic && shouldCompressMimeType(mimeType)) {
@@ -442,11 +444,11 @@ async function buildRewrittenHtmlResponse(
 			headers['Content-Encoding'] = 'gzip'
 		}
 
-		applyCustomHeaders(headers, filePath, settings)
+		applyCustomHeaders(headers, filePath, settings, { sharedOrigin })
 		return new Response(output, { headers })
 	} catch (err) {
 		logger.warn('Failed to rewrite HTML on demand, serving original', { filePath, error: err })
-		return buildResponseFromStorageResult(result, filePath, settings, requestHeaders)
+		return buildResponseFromStorageResult(result, filePath, settings, requestHeaders, sharedOrigin)
 	}
 }
 
@@ -946,10 +948,11 @@ export async function serveFileInternalWithRewrite(
 				basePath,
 				settings,
 				requestHeaders,
+				true,
 			)
 		}
 
-		return buildResponseFromStorageResult(fileResult.result, fileResult.filePath, settings, requestHeaders)
+		return buildResponseFromStorageResult(fileResult.result, fileResult.filePath, settings, requestHeaders, true)
 	}
 
 	// Normalize the request path (keep empty for root, remove trailing slash for others)

--- a/apps/hosting-service/src/lib/request-utils.test.ts
+++ b/apps/hosting-service/src/lib/request-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import type { Record as WispSettings } from '@wispplace/lexicons/types/place/wisp/settings'
+import { applyCustomHeaders } from './request-utils'
+
+const settings = {
+	$type: 'place.wisp.settings',
+	directoryListing: false,
+	cleanUrls: false,
+	headers: [
+		{ name: 'Service-Worker-Allowed', value: '/' },
+		{ name: 'X-Site-Header', value: 'ok' },
+	],
+} satisfies WispSettings
+
+describe('applyCustomHeaders', () => {
+	test('blocks service worker scope expansion on the shared origin', () => {
+		const headers: Record<string, string> = {}
+
+		applyCustomHeaders(headers, 'sw.js', settings, { sharedOrigin: true })
+
+		expect(headers['Service-Worker-Allowed']).toBeUndefined()
+		expect(headers['X-Site-Header']).toBe('ok')
+	})
+
+	test('allows service worker scope headers on isolated custom domains', () => {
+		const headers: Record<string, string> = {}
+
+		applyCustomHeaders(headers, 'sw.js', settings)
+
+		expect(headers['Service-Worker-Allowed']).toBe('/')
+	})
+})

--- a/apps/hosting-service/src/lib/request-utils.ts
+++ b/apps/hosting-service/src/lib/request-utils.ts
@@ -4,6 +4,12 @@
 
 import type { Record as WispSettings } from '@wispplace/lexicons/types/place/wisp/settings'
 
+const SHARED_ORIGIN_BLOCKED_HEADERS = new Set(['service-worker-allowed'])
+
+interface CustomHeaderOptions {
+	sharedOrigin?: boolean
+}
+
 /**
  * Default index file names to check for directory requests
  * Will be checked in order until one is found
@@ -39,10 +45,19 @@ export function matchGlob(path: string, pattern: string): boolean {
 /**
  * Apply custom headers from settings to response headers
  */
-export function applyCustomHeaders(headers: Record<string, string>, filePath: string, settings: WispSettings | null) {
+export function applyCustomHeaders(
+	headers: Record<string, string>,
+	filePath: string,
+	settings: WispSettings | null,
+	options: CustomHeaderOptions = {},
+) {
 	if (!settings?.headers || settings.headers.length === 0) return
 
 	for (const customHeader of settings.headers) {
+		if (options.sharedOrigin && SHARED_ORIGIN_BLOCKED_HEADERS.has(customHeader.name.trim().toLowerCase())) {
+			continue
+		}
+
 		// If path glob is specified, check if it matches
 		if (customHeader.path) {
 			if (!matchGlob(filePath, customHeader.path)) {


### PR DESCRIPTION
## Summary

Strip `Service-Worker-Allowed` case-insensitively when serving user content from the shared `sites.wisp.place` origin, while preserving it for custom domains.

## Why

Wisp site content is intentionally public. The concern is cross-tenant browser authority on the shared origin, not public readability.

Finding: https://chatgpt.com/codex/cloud/security/findings/80875f9dad6881918516aea9cbc6f01f

## Impact

A hosted site cannot use this response header to broaden service-worker scope across the shared hosting origin.

## Root cause

User-controlled headers were forwarded without a shared-origin denylist for browser security headers.

## Verification

- 2 focused header tests pass
- hosting-service production build passes
- `bun check` reaches the pre-existing unrelated `releaseLeadership` error in firehose-service