### PR TITLE
Validate public Wisp records before caching

### DIFF
--- a/apps/firehose-service/src/lib/cache-writer.ts
+++ b/apps/firehose-service/src/lib/cache-writer.ts
@@ -9,9 +9,13 @@ import { shouldCompressMimeType } from '@wispplace/atproto-utils/compression'
 import { MAX_BLOB_SIZE, MAX_FILE_COUNT, MAX_SITE_SIZE, MAX_SITE_SIZE_SUPPORTER } from '@wispplace/constants'
 import { collectFileCidsFromEntries, countFilesInDirectory, normalizeFileCids } from '@wispplace/fs-utils'
 import { isHtmlContent, rewriteHtmlPaths } from '@wispplace/fs-utils/html-rewriter'
+import { parseLexiconJson } from '@wispplace/lexicons/public-json'
 import type { Directory, Entry, File, Record as WispFsRecord } from '@wispplace/lexicons/types/place/wisp/fs'
+import { validateRecord as validateFsRecord } from '@wispplace/lexicons/types/place/wisp/fs'
 import type { Record as WispSettings } from '@wispplace/lexicons/types/place/wisp/settings'
+import { validateRecord as validateSettingsRecord } from '@wispplace/lexicons/types/place/wisp/settings'
 import type { Record as SubfsRecord } from '@wispplace/lexicons/types/place/wisp/subfs'
+import { validateRecord as validateSubfsRecord } from '@wispplace/lexicons/types/place/wisp/subfs'
 import { createLogger } from '@wispplace/observability'
 import { safeFetchBlob, safeFetchJson } from '@wispplace/safe-fetch'
 import { publishCacheInvalidation } from './cache-invalidation'
@@ -103,8 +107,15 @@ export async function fetchSiteRecord(
 		const url = `${pdsEndpoint}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=place.wisp.fs&rkey=${encodeURIComponent(rkey)}`
 		const data = await safeFetchJson(url)
 
+		const record = parseLexiconJson<WispFsRecord>(data.value)
+		const validation = validateFsRecord(record)
+		if (!validation.success) {
+			logger.warn('Rejected invalid site record', { did, rkey, error: validation.error?.message })
+			return null
+		}
+
 		return {
-			record: data.value as WispFsRecord,
+			record,
 			cid: data.cid || '',
 		}
 	} catch (err) {
@@ -150,8 +161,15 @@ export async function listSiteRecordsForDid(
 		const pageRecords = Array.isArray(data.records) ? data.records : []
 		for (const row of pageRecords) {
 			const uri = row.uri
-			const record = row.value as WispFsRecord | undefined
-			if (!uri || !record || record.$type !== 'place.wisp.fs') continue
+			if (!uri || !row.value) continue
+
+			let record: WispFsRecord
+			try {
+				record = parseLexiconJson<WispFsRecord>(row.value)
+			} catch {
+				continue
+			}
+			if (!validateFsRecord(record).success) continue
 
 			const uriParts = uri.split('/')
 			const rkey = uriParts[uriParts.length - 1]
@@ -190,8 +208,15 @@ export async function fetchSettingsRecord(
 		const url = `${endpoint}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=place.wisp.settings&rkey=${encodeURIComponent(rkey)}`
 		const data = await safeFetchJson(url)
 
+		const record = parseLexiconJson<WispSettings>(data.value)
+		const validation = validateSettingsRecord(record)
+		if (!validation.success) {
+			logger.warn('Rejected invalid settings record', { did, rkey, error: validation.error?.message })
+			return null
+		}
+
 		return {
-			record: data.value as WispSettings,
+			record,
 			cid: data.cid || '',
 		}
 	} catch (err) {
@@ -220,7 +245,8 @@ async function fetchSubfsRecord(uri: string, pdsEndpoint: string): Promise<Subfs
 		const url = `${pdsEndpoint}/xrpc/com.atproto.repo.getRecord?repo=${encodeURIComponent(did)}&collection=${encodeURIComponent(collection)}&rkey=${encodeURIComponent(rkey)}`
 		const response = await safeFetchJson(url)
 
-		return (response?.value as SubfsRecord) || null
+		const record = response?.value ? parseLexiconJson<SubfsRecord>(response.value) : undefined
+		return record && validateSubfsRecord(record).success ? record : null
 	} catch {
 		return null
 	}

--- a/apps/firehose-service/src/lib/firehose.ts
+++ b/apps/firehose-service/src/lib/firehose.ts
@@ -7,6 +7,7 @@ import { IdResolver } from '@atproto/identity'
 import { Firehose } from '@atproto/sync'
 import { BunFirehose, type CommitEvt, type Event, isBun } from '@wispplace/bun-firehose'
 import type { Record as WispSettings } from '@wispplace/lexicons/types/place/wisp/settings'
+import { validateRecord as validateSettingsRecord } from '@wispplace/lexicons/types/place/wisp/settings'
 import { createLogger } from '@wispplace/observability'
 import { config } from '../config'
 import {
@@ -168,9 +169,11 @@ async function handleEvent(evt: Event | CommitEvt): Promise<void> {
 				try {
 					if (commitEvt.event === 'delete') {
 						await handleSettingsDelete(did, rkey)
-					} else if (record) {
+					} else if (record && validateSettingsRecord(record).success) {
 						const cidStr = cid?.toString() || ''
 						await handleSettingsUpdate(did, rkey, record as WispSettings, cidStr)
+					} else {
+						logger.warn(`[place.wisp.settings] Skipping invalid record`, { did, rkey })
 					}
 				} catch (err) {
 					logger.error(`[place.wisp.settings] Error handling event`, err, { did, rkey, event: commitEvt.event })

--- a/apps/hosting-service/src/lib/on-demand-cache.ts
+++ b/apps/hosting-service/src/lib/on-demand-cache.ts
@@ -14,7 +14,9 @@ import { extractBlobCid, getPdsForDid } from '@wispplace/atproto-utils'
 import { shouldCompressMimeType } from '@wispplace/atproto-utils/compression'
 import { MAX_BLOB_SIZE, MAX_FILE_COUNT, MAX_SITE_SIZE, MAX_SITE_SIZE_SUPPORTER } from '@wispplace/constants'
 import { collectFileCidsFromEntries, countFilesInDirectory } from '@wispplace/fs-utils'
+import { parseLexiconJson } from '@wispplace/lexicons/public-json'
 import type { Directory, Entry, File, Record as WispFsRecord } from '@wispplace/lexicons/types/place/wisp/fs'
+import { validateRecord as validateFsRecord } from '@wispplace/lexicons/types/place/wisp/fs'
 import { createLogger } from '@wispplace/observability'
 import { safeFetchBlob, safeFetchJson } from '@wispplace/safe-fetch'
 import { isSupporter, releaseLock, tryAcquireLock, upsertSiteCache } from './db'
@@ -129,11 +131,12 @@ async function doFetchAndCache(did: string, rkey: string): Promise<boolean> {
 			return false
 		}
 
-		const record = data.value as WispFsRecord
+		const record = parseLexiconJson<WispFsRecord>(data.value)
 		const recordCid = data.cid || ''
 
-		if (!record?.root?.entries) {
-			logger.error('Invalid record structure', undefined, { did, rkey })
+		const validation = validateFsRecord(record)
+		if (!validation.success) {
+			logger.error('Invalid site record', undefined, { did, rkey, error: validation.error?.message })
 			return false
 		}
 
@@ -225,12 +228,7 @@ function validateEntryNames(entries: Entry[], pathPrefix: string = ''): void {
 
 function isSafeEntryName(name: string): boolean {
 	return (
-		name !== '' &&
-		name !== '.' &&
-		name !== '..' &&
-		!name.includes('/') &&
-		!name.includes('\\') &&
-		!name.includes('\0')
+		name !== '' && name !== '.' && name !== '..' && !name.includes('/') && !name.includes('\\') && !name.includes('\0')
 	)
 }
 

--- a/apps/hosting-service/src/lib/utils.ts
+++ b/apps/hosting-service/src/lib/utils.ts
@@ -1,8 +1,10 @@
 import { didWebToHttps, extractBlobCid, getPdsForDid, resolveDid } from '@wispplace/atproto-utils'
 import { sanitizePath } from '@wispplace/fs-utils'
+import { parseLexiconJson } from '@wispplace/lexicons/public-json'
 import type { Directory, Entry } from '@wispplace/lexicons/types/place/wisp/fs'
 import type { Record as WispSettings } from '@wispplace/lexicons/types/place/wisp/settings'
 import type { Record as SubfsRecord } from '@wispplace/lexicons/types/place/wisp/subfs'
+import { validateRecord as validateSubfsRecord } from '@wispplace/lexicons/types/place/wisp/subfs'
 import { safeFetchJson } from '@wispplace/safe-fetch'
 import { getSiteSettingsCache } from './db'
 
@@ -61,7 +63,13 @@ async function fetchSubfsRecord(uri: string, pdsEndpoint: string): Promise<Subfs
 			return null
 		}
 
-		return response.value as SubfsRecord
+		const record = parseLexiconJson<SubfsRecord>(response.value)
+		if (!validateSubfsRecord(record).success) {
+			console.error('Invalid subfs record:', uri)
+			return null
+		}
+
+		return record
 	} catch (err) {
 		console.error('Failed to fetch subfs record:', uri, err)
 		return null

--- a/packages/@wispplace/lexicons/package.json
+++ b/packages/@wispplace/lexicons/package.json
@@ -78,6 +78,10 @@
       "types": "./src/lexicons.ts",
       "default": "./src/lexicons.ts"
     },
+    "./public-json": {
+      "types": "./src/public-json.ts",
+      "default": "./src/public-json.ts"
+    },
     "./util": {
       "types": "./src/util.ts",
       "default": "./src/util.ts"

--- a/packages/@wispplace/lexicons/src/public-json.test.ts
+++ b/packages/@wispplace/lexicons/src/public-json.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+import { parseLexiconJson } from './public-json'
+import type { Record as WispFsRecord } from './types/place/wisp/fs'
+import { validateRecord } from './types/place/wisp/fs'
+
+describe('parseLexiconJson', () => {
+	test('hydrates public JSON blob references before lexicon validation', () => {
+		const record = parseLexiconJson<WispFsRecord>({
+			$type: 'place.wisp.fs',
+			site: 'example',
+			createdAt: '2026-07-14T00:00:00.000Z',
+			root: {
+				type: 'directory',
+				entries: [
+					{
+						name: 'index.html',
+						node: {
+							$type: 'place.wisp.fs#file',
+							type: 'file',
+							blob: {
+								$type: 'blob',
+								ref: { $link: 'bafkreie56uer6qjm7mqckb52xtd3mecy77t5axnumzdcnhjzpcwiin6zue' },
+								mimeType: 'text/html',
+								size: 12,
+							},
+						},
+					},
+				],
+			},
+		})
+
+		expect(validateRecord(record).success).toBe(true)
+	})
+})

--- a/packages/@wispplace/lexicons/src/public-json.ts
+++ b/packages/@wispplace/lexicons/src/public-json.ts
@@ -1,0 +1,9 @@
+import { jsonToLex } from '@atproto/lexicon'
+
+/**
+ * Convert the JSON representation returned by AT Protocol XRPC endpoints
+ * into the in-memory representation expected by these generated validators.
+ */
+export function parseLexiconJson<T>(value: unknown): T {
+	return jsonToLex(value as Parameters<typeof jsonToLex>[0]) as T
+}


### PR DESCRIPTION
## Summary

Hydrate public XRPC JSON into ATProto runtime values and validate `place.wisp.fs`, `place.wisp.subfs`, and `place.wisp.settings` records before using or caching them.

## Why

These records are public by design. Public does not mean trusted: malformed records should not reach storage projection or request-serving paths.

Finding: https://chatgpt.com/codex/cloud/security/findings/d0ea9d2b4e9c8191802558ec4a0e5dc2

## Impact

Malformed public records are rejected at ingestion/read boundaries. Valid BlobRefs from live PDS JSON continue to work.

## Root cause

Raw XRPC JSON was cast to generated TypeScript types without running the generated runtime validators or hydrating BlobRefs.

## Verification

- focused public-record validation test passes
- main-app and hosting-service production builds pass
- firehose-service production image builds
- full Docker E2E passes against a live PDS: auth, upload, firehose projection, S3 cold-to-hot serving, domain invalidation, record deletion, and cache eviction
- `bun check` reaches the pre-existing unrelated `releaseLeadership` error in firehose-service