### PR TITLE
Bound safe fetch attempts

### DIFF
--- a/packages/@wispplace/safe-fetch/src/index.test.ts
+++ b/packages/@wispplace/safe-fetch/src/index.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { DEFAULT_FETCH_TIMEOUT_MS, safeFetch } from './index'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+	globalThis.fetch = originalFetch
+})
+
+describe('safeFetch public-request defaults', () => {
+	test('uses a bounded control-plane timeout', () => {
+		expect(DEFAULT_FETCH_TIMEOUT_MS).toBe(30_000)
+	})
+
+	test('does not retry transient failures unless requested', async () => {
+		let attempts = 0
+		globalThis.fetch = (async () => {
+			attempts++
+			const error = new Error('fetch failed') as Error & { code: string }
+			error.code = 'ECONNRESET'
+			throw error
+		}) as unknown as typeof fetch
+
+		await expect(safeFetch('https://example.com/data')).rejects.toThrow('fetch failed')
+		expect(attempts).toBe(1)
+	})
+})

--- a/packages/@wispplace/safe-fetch/src/index.ts
+++ b/packages/@wispplace/safe-fetch/src/index.ts
@@ -17,7 +17,7 @@ const BLOCKED_IP_RANGES = [
 
 const BLOCKED_HOSTS = ['localhost', 'metadata.google.internal', '169.254.169.254']
 
-const FETCH_TIMEOUT = 120000 // 120 seconds
+export const DEFAULT_FETCH_TIMEOUT_MS = 30000 // 30 seconds for control-plane requests
 const FETCH_TIMEOUT_BLOB = 120000 // 2 minutes for blob downloads
 const MAX_RESPONSE_SIZE = 10 * 1024 * 1024 // 10MB
 const MAX_JSON_SIZE = 1024 * 1024 // 1MB
@@ -136,8 +136,8 @@ export async function safeFetch(
 	url: string,
 	options?: RequestInit & { maxSize?: number; timeout?: number; retry?: boolean },
 ): Promise<Response> {
-	const shouldRetry = options?.retry !== false // Default to true
-	const timeoutMs = options?.timeout ?? FETCH_TIMEOUT
+	const shouldRetry = options?.retry === true // Retries must be explicitly enabled by background callers
+	const timeoutMs = options?.timeout ?? DEFAULT_FETCH_TIMEOUT_MS
 	const maxSize = options?.maxSize ?? MAX_RESPONSE_SIZE
 
 	// Parse and validate URL (done once, outside retry loop)


### PR DESCRIPTION
## Summary

Give JSON/control-plane fetches a 30-second default timeout and make retries opt-in instead of automatic.

## Why

ATProto endpoints and records are intentionally network-accessible. The concern is allowing a slow or failing upstream to retain request resources for multiple long attempts.

Findings:
- https://chatgpt.com/codex/cloud/security/findings/18eae9699118819189e031e8a8eaaa90
- https://chatgpt.com/codex/cloud/security/findings/43ba70de75d4819190c98dc957ade7bc

## Impact

Default callers perform one bounded attempt. Callers that genuinely need retries can still request them explicitly.

## Root cause

The shared helper combined a long timeout with automatic retry behavior for all call sites.

## Verification

- 2 safe-fetch tests pass
- main-app and hosting-service production builds pass
- `bun check` reaches the pre-existing unrelated `releaseLeadership` error in firehose-service