### PR TITLE
Scope private-site CSRF exception to share redemption

### DIFF
--- a/apps/main-app/src/index.ts
+++ b/apps/main-app/src/index.ts
@@ -225,7 +225,7 @@ export const app = new Elysia({
 		}
 	})
 	// Private-site subdomains (<siteId>.priv.<host>) legitimately POST /private/redeem
-	// to redeem audience-scoped shares, so allow that origin through CSRF.
+	// to redeem audience-scoped shares. The middleware scopes this exception to that path.
 	.onBeforeHandle(csrfProtection([`.${process.env.PRIVATE_HOST || `priv.${BASE_HOST}`}`]))
 	.get('/', async ({ request, set }) => {
 		// Build dynamic login URL for AT Protocol OAuth entryway

--- a/apps/main-app/src/lib/csrf.test.ts
+++ b/apps/main-app/src/lib/csrf.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { verifyRequestOrigin } from './csrf'
+import { csrfProtection, verifyRequestOrigin } from './csrf'
 
 describe('verifyRequestOrigin', () => {
 	test('should accept matching origin and host', () => {
@@ -86,5 +86,39 @@ describe('verifyRequestOrigin', () => {
 	test('should handle IPv6 addresses', () => {
 		expect(verifyRequestOrigin('http://[::1]:8000', ['[::1]:8000'])).toBe(true)
 		expect(verifyRequestOrigin('http://[2001:db8::1]', ['[2001:db8::1]'])).toBe(true)
+	})
+})
+
+describe('csrfProtection', () => {
+	const privateOrigin = 'https://amber-anchor-fox-1234.priv.wisp.place'
+	const protect = csrfProtection(['.priv.wisp.place'])
+
+	const run = (path: string) => {
+		const set: { status?: number | string } = {}
+		const result = protect({
+			request: new Request(`https://wisp.place${path}`, {
+				method: 'POST',
+				headers: { Host: 'wisp.place', Origin: privateOrigin },
+			}),
+			set,
+		})
+		return { result, set }
+	}
+
+	test('allows private-site origins for scoped share redemption', () => {
+		const { result, set } = run('/private/redeem')
+		expect(result).toBeUndefined()
+		expect(set.status).toBeUndefined()
+	})
+
+	test('rejects private-site origins for other unsafe routes', () => {
+		for (const path of ['/wisp/upload-files', '/api/auth/logout', '/api/domain/claim']) {
+			const { result, set } = run(path)
+			expect(set.status).toBe(403)
+			expect(result).toEqual({
+				error: 'CSRF validation failed',
+				message: 'Request origin does not match host',
+			})
+		}
 	})
 })

--- a/apps/main-app/src/lib/csrf.ts
+++ b/apps/main-app/src/lib/csrf.ts
@@ -39,9 +39,9 @@ export function verifyRequestOrigin(origin: string, allowedHosts: string[]): boo
  * not propagate to those routes, leaving CSRF silently unenforced. Applying the
  * hook directly on the root instance propagates to all child `.use()` routes.
  *
- * `allowedExtraOrigins` permits additional exact hosts (e.g. the private-site
- * origin that legitimately POSTs /private/redeem). Entries beginning with `.`
- * match any subdomain of that suffix, so `<siteId>.priv.<host>` is covered.
+ * `allowedExtraOrigins` permits additional hosts only for /private/redeem.
+ * Entries beginning with `.` match any subdomain of that suffix, so
+ * `<siteId>.priv.<host>` is covered without exempting any other route.
  *
  * Usage:
  * ```ts
@@ -66,14 +66,16 @@ export const csrfProtection =
 		const originHeader = request.headers.get('Origin')
 		// Use X-Forwarded-Host if behind a proxy, otherwise use Host
 		const hostHeader = request.headers.get('X-Forwarded-Host') || request.headers.get('Host')
+		const path = new URL(request.url).pathname
+		const extraHosts = path === '/private/redeem' ? allowedExtraOrigins : []
 
-		// Validate origin matches host or an explicitly allowlisted origin
-		if (!originHeader || !hostHeader || !verifyRequestOrigin(originHeader, [hostHeader, ...allowedExtraOrigins])) {
+		// Extra origins are trusted only for the scoped-share redemption endpoint.
+		if (!originHeader || !hostHeader || !verifyRequestOrigin(originHeader, [hostHeader, ...extraHosts])) {
 			logger.warn('[CSRF] Request blocked', {
 				method,
 				origin: originHeader,
 				host: hostHeader,
-				path: new URL(request.url).pathname,
+				path,
 			})
 
 			set.status = 403


### PR DESCRIPTION
### Motivation
- A recent change allowed any host suffix beginning with `.` to bypass CSRF checks globally, which lets attacker-controlled private-site subdomains perform state-changing POSTs to the main app using victim cookies. 
- The intent of this change is to restrict that exception so only the intended scoped-share flow (`POST /private/redeem`) can use the private-site allowlist, restoring strict same-origin verification for all other unsafe routes.

### Description
- Restrict `csrfProtection` so `allowedExtraOrigins` are honored only when the request path is `'/private/redeem'`, otherwise only the main `Host` is accepted (`apps/main-app/src/lib/csrf.ts`).
- Preserve the root-level hook placement so CSRF middleware still propagates to mounted route modules and clarify the comment in `apps/main-app/src/index.ts` that the private-site exception is path-scoped.
- Add regression tests that exercise `csrfProtection` to allow private-site origins for `/private/redeem` and reject the same origins for representative unsafe endpoints such as `/wisp/upload-files`, `/api/auth/logout`, and `/api/domain/claim` (`apps/main-app/src/lib/csrf.test.ts`).
- Commit updates touched `apps/main-app/src/lib/csrf.ts`, `apps/main-app/src/lib/csrf.test.ts`, and a documentation comment in `apps/main-app/src/index.ts`.

### Testing
- `git diff --check` was run and passed. 
- Attempted `bun test apps/main-app/src/lib/csrf.test.ts` which exercised the new unit tests but the run errored due to a missing runtime dependency `@opentelemetry/api` from the observability package so tests did not complete. 
- Attempted `bun tsc --noEmit` and `bunx biome check` but those checks could not be completed in this environment (no `tsc` binary available and Biome dependency resolution returned HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6b93bac7e8832faa72f54b8e5a6043)