### PR TITLE
Cap and deduplicate firehose revalidation queue

### DIFF
--- a/apps/firehose-service/.env.example
+++ b/apps/firehose-service/.env.example
@@ -10,6 +10,8 @@ FIREHOSE_MAX_CONCURRENCY=5
 # Redis (cache invalidation + revalidation queue)
 REDIS_URL=redis://localhost:6379
 WISP_REVALIDATE_FAILURE_BACKOFF_SECONDS=600
+WISP_REVALIDATE_STREAM_MAXLEN=10000
+WISP_REVALIDATE_DEDUPE_TTL_SECONDS=60
 
 # S3 Storage (leave empty for local disk fallback)
 S3_BUCKET=

--- a/apps/firehose-service/src/config.ts
+++ b/apps/firehose-service/src/config.ts
@@ -28,6 +28,8 @@ export const config = {
 	redisUrl: process.env.REDIS_URL,
 	revalidateStream: process.env.WISP_REVALIDATE_STREAM || 'wisp:revalidate',
 	revalidateGroup: process.env.WISP_REVALIDATE_GROUP || 'firehose-service',
+	revalidateStreamMaxLen: parseInt(process.env.WISP_REVALIDATE_STREAM_MAXLEN || '10000', 10),
+	revalidateDedupeTtlSeconds: parseInt(process.env.WISP_REVALIDATE_DEDUPE_TTL_SECONDS || '60', 10),
 	cacheInvalidationStream: process.env.WISP_CACHE_INVALIDATION_STREAM || 'wisp:cache-invalidate-stream',
 	cacheInvalidationStreamMaxLen: parseInt(process.env.WISP_CACHE_INVALIDATION_STREAM_MAXLEN || '10000', 10),
 

--- a/apps/firehose-service/src/lib/cache-invalidation.ts
+++ b/apps/firehose-service/src/lib/cache-invalidation.ts
@@ -82,9 +82,19 @@ export async function enqueueSiteRevalidation(did: string, rkey: string, reason:
 	const redis = getPublisher()
 	if (!redis) return false
 
+	const dedupeKey = `revalidate:site:other:${did}:${rkey}`
+	let dedupeAcquired = false
+	let enqueued = false
 	try {
+		const set = await redis.set(dedupeKey, '1', 'EX', config.revalidateDedupeTtlSeconds, 'NX')
+		if (!set) return false
+		dedupeAcquired = true
+
 		const streamId = await redis.xadd(
 			config.revalidateStream,
+			'MAXLEN',
+			'~',
+			config.revalidateStreamMaxLen.toString(),
 			'*',
 			'did',
 			did,
@@ -95,9 +105,11 @@ export async function enqueueSiteRevalidation(did: string, rkey: string, reason:
 			'ts',
 			Date.now().toString(),
 		)
+		enqueued = true
 		logger.info(`[Revalidate] Enqueued ${did}/${rkey} after firehose failure`, { reason, streamId })
 		return true
 	} catch (err) {
+		if (dedupeAcquired && !enqueued) await redis.del(dedupeKey).catch(() => undefined)
 		logger.error('[Revalidate] Failed to enqueue site after firehose failure', err, { did, rkey, reason })
 		return false
 	}


### PR DESCRIPTION
### Motivation
- Prevent an attacker-controlled stream of public firehose events from exhausting Redis by writing untrimmed, duplicate entries to the revalidation stream. 
- Ensure revalidation enqueueing is rate-limited/deduplicated per-site so repeated failures don't amplify work or retained stream size. 
- Make the safety parameters configurable so deployments can tune retention and dedupe TTLs.

### Description
- Added two new config options `revalidateStreamMaxLen` and `revalidateDedupeTtlSeconds` and exposed them in the firehose `.env.example` as `WISP_REVALIDATE_STREAM_MAXLEN` and `WISP_REVALIDATE_DEDUPE_TTL_SECONDS`.
- Updated `enqueueSiteRevalidation` to acquire a per-site dedupe key via `SET <key> EX <ttl> NX` before producing to the revalidation stream and to return early if the key already exists.
- Bound the stream write with an approximate `MAXLEN ~ <revalidateStreamMaxLen>` argument to `XADD` so the stream is trimmed as configured.
- Ensure the dedupe key is removed if enqueueing fails (so subsequent events can retry) by only deleting the key when it was acquired but the `XADD` did not succeed.

### Testing
- `git diff --check` ran and passed without whitespace errors. 
- `bun run --cwd apps/firehose-service check` was attempted but blocked by the repository TypeScript configuration (installed tool rejected deprecated `baseUrl` without `ignoreDeprecations`).
- `bun test apps/firehose-service/src/lib/revalidate-worker.test.ts` was attempted but failed to run due to missing runtime dependencies (e.g., `ioredis` not installed), preventing full test execution.
- `bunx biome check ...` was attempted but blocked when resolving tooling dependencies returned an HTTP 403 from the package registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6b8a72dd1c832fa69a1607710fd5bc)